### PR TITLE
import globally unique package names not relative

### DIFF
--- a/effe.go
+++ b/effe.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"effe/logic"
 	"flag"
 	"fmt"
+	"github.com/siscia/effe/logic"
 	"log/syslog"
 	"net/http"
 	"sync"


### PR DESCRIPTION
Made the package import globally unique so that the package is "go-gettable" as described here:
- http://blog.golang.org/organizing-go-code

> Sometimes people set GOPATH to the root of their source repository and put their packages in directories relative to the repository root, such as "src/my/package". On one hand, this keeps the import paths short ("my/package" instead of "github.com/me/project/my/package"), but on the other it breaks go get and forces users to re-set their GOPATH to use the package. Don't do this.
